### PR TITLE
Support arbitrary keys

### DIFF
--- a/lib/process_tree.ex
+++ b/lib/process_tree.ex
@@ -31,7 +31,7 @@ defmodule ProcessTree do
 
   Returns the first non-nil value found in the tree. If no value is found, returns `nil`.
   """
-  @spec get(atom()) :: any()
+  @spec get(term()) :: any()
   def get(key) do
     case Process.get(key) do
       nil ->
@@ -63,7 +63,7 @@ defmodule ProcessTree do
   value = ProcessTree.get(:some_key, default: default_value)
   ```
   """
-  @spec get(atom(), default: any()) :: any()
+  @spec get(term(), default: any()) :: any()
   def get(key, default: default_value) do
     case get(key) do
       nil ->
@@ -200,7 +200,6 @@ defmodule ProcessTree do
     defp process_info_parent(_pid), do: nil
   end
 
-
   @spec ancestor_value(any(), id(), [id()]) :: any()
   defp ancestor_value(key, pid_or_name, dictionary_ancestors) do
     cond do
@@ -235,7 +234,13 @@ defmodule ProcessTree do
         nil
 
       {:dictionary, dictionary} ->
-        Keyword.get(dictionary, key)
+        case List.keyfind(dictionary, key, 0) do
+          {_key, value} ->
+            value
+
+          nil ->
+            nil
+        end
     end
   end
 

--- a/test/process_tree_test.exs
+++ b/test/process_tree_test.exs
@@ -292,6 +292,14 @@ defmodule ProcessTreeTest do
 
       assert Process.get(:foo) == :bar
     end
+
+    test "supports arbitrary keys" do
+      Process.put({:some, :disparate, :key}, :bar)
+
+      assert ProcessTree.get({:some, :disparate, :key}) == :bar
+
+      assert Process.get({:some, :disparate, :key}) == :bar
+    end
   end
 
   defp full_name(pid_name) do


### PR DESCRIPTION
The Process dictionary supports arbitrary keys, not just atoms.

Currently the library is using `Keyword.get` to find a value in the process dict. Keyword lists must have atom keys, and while in a lot of scenarios this is true for the Process dict, it's not required.

This PR updates the code to use `List.keyfind/3` instead, which supports searching a tuple list with arbitrary values in any position.