### PR TITLE
Added support for $callers

### DIFF
--- a/bin/dialyzer
+++ b/bin/dialyzer
@@ -57,19 +57,19 @@ mix local.hex --force
 mix dialyzer
 
 asdf local erlang 25.3.2.7
-asdf local elixir 1.17.0-otp-25
+asdf local elixir 1.17.3-otp-25
 rm -rf _build
 mix local.hex --force
 mix dialyzer
 
 asdf local erlang 26.0
-asdf local elixir 1.17.0-otp-26
+asdf local elixir 1.17.3-otp-26
 rm -rf _build
 mix local.hex --force
 mix dialyzer
 
 asdf local erlang 27.0
-asdf local elixir 1.17.0-otp-27
+asdf local elixir 1.17.3-otp-27
 rm -rf _build
 mix local.hex --force
 mix dialyzer

--- a/bin/script_builder.exs
+++ b/bin/script_builder.exs
@@ -14,9 +14,9 @@ defmodule ScriptBuilder do
       {erlang_build("25"), "1.16.3-otp-25"},
       {erlang_build("26"), "1.16.3-otp-26"},
 
-      {erlang_build("25"), "1.17.0-otp-25"},
-      {erlang_build("26"), "1.17.0-otp-26"},
-      {erlang_build("27"), "1.17.0-otp-27"},
+      {erlang_build("25"), "1.17.3-otp-25"},
+      {erlang_build("26"), "1.17.3-otp-26"},
+      {erlang_build("27"), "1.17.3-otp-27"},
     ]
   end
 
@@ -68,4 +68,4 @@ defmodule ScriptBuilder do
   end
 end
 
-ScriptBuilder.dialyzer_commands()
+ScriptBuilder.test_commands()

--- a/bin/test
+++ b/bin/test
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -euxo pipefail
+set -euo pipefail
 
 asdf local erlang 24.3.4.14
 asdf local elixir 1.14.5-otp-24
@@ -48,17 +48,17 @@ mix local.hex --force
 mix test
 
 asdf local erlang 25.3.2.7
-asdf local elixir 1.17.0-otp-25
+asdf local elixir 1.17.3-otp-25
 mix local.hex --force
 mix test
 
 asdf local erlang 26.0
-asdf local elixir 1.17.0-otp-26
+asdf local elixir 1.17.3-otp-26
 mix local.hex --force
 mix test
 
 asdf local erlang 27.0
-asdf local elixir 1.17.0-otp-27
+asdf local elixir 1.17.3-otp-27
 mix local.hex --force
 mix test
 

--- a/lib/process_tree/otp_release.ex
+++ b/lib/process_tree/otp_release.ex
@@ -25,7 +25,7 @@ defmodule ProcessTree.OtpRelease do
           Process.info(self(), {:dictionary, :foo})
           true
         rescue
-          _  -> false
+          _ -> false
         end
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -46,7 +46,7 @@ defmodule ProcessTree.MixProject do
         "examples/environment-variable-example.md"
       ],
       groups_for_extras: [
-        "Examples": ["examples/environment-variable-example.md"]
+        Examples: ["examples/environment-variable-example.md"]
       ],
       main: "ProcessTree",
       source_ref: "v#{@version}"

--- a/test/process_tree_test.exs
+++ b/test/process_tree_test.exs
@@ -348,6 +348,24 @@ defmodule ProcessTreeTest do
     end
   end
 
+  describe "$callers" do
+    test "$callers test" do
+      dbg(self())
+
+      {:ok, supervisor} = Task.Supervisor.start_link()
+
+      Task.Supervisor.async_nolink(supervisor, fn ->
+        dbg(Process.get(:"$callers"))
+        parent = ProcessTree.parent(self())
+        dbg(parent)
+        grandparent = ProcessTree.parent(parent)
+        dbg(grandparent)
+      end)
+
+      :timer.sleep 1000
+    end
+  end
+
   defp full_name(pid_name) do
     prefix = Process.get(:process_name_prefix)
     (prefix <> Atom.to_string(pid_name)) |> String.to_atom()


### PR DESCRIPTION
For each process it examines, ProcessTree:
1) looks in the process' dictionary. If a value is not found, then:
2) It looks up to the process' parent. If a value is not found, then:
3) It looks up to its caller (if there is one)