### PR TITLE
Fix broken typespec

### DIFF
--- a/lib/process_tree.ex
+++ b/lib/process_tree.ex
@@ -251,7 +251,7 @@ defmodule ProcessTree do
     defp process_info_parent(_pid), do: nil
   end
 
-  @spec get_dictionary_value(id(), atom()) :: term()
+  @spec get_dictionary_value(id(), term()) :: term()
   defp get_dictionary_value(nil, _key), do: nil
 
   defp get_dictionary_value(name, _key) when is_atom(name) do


### PR DESCRIPTION
I kept getting these kinds of dialyzer errors:

```
lib/pluto_web.ex:1636:call
The function call will not succeed.

ProcessTree.get({PlutoWeb, :config})

will never return since the 1st arguments differ
from the success typing arguments:

(atom())
```

Turns out this was the culprit.